### PR TITLE
Change Dataset Column Length

### DIFF
--- a/dataikuapi/dss/dataset.py
+++ b/dataikuapi/dss/dataset.py
@@ -818,6 +818,15 @@ class DSSDatasetSettings(DSSTaggableObjectSettings):
     def add_raw_schema_column(self, column):
         self.settings["schema"]["columns"].append(column)
 
+    def update_string_column_len(self, column, length):
+        """
+        Update the length of a string column in a Dataset schema
+        """
+        columns = self.settings["schema"]["columns"]
+        for c in columns:
+            if c['name'] == column:
+                c['maxLength'] = length
+
     @property
     def is_feature_group(self):
         """


### PR DESCRIPTION
As a Dataiku platform user, I want to manually set the length of a column in a Dataset scso that I can have a resilient flow. 

Dataset settings currently has a host of functions to retireve the dataset's schema and set types, but not length for a string column. 

I have flows that fail due to longer string lengths outside fo the sample used to auto detect the schema for a dataset. 

This PR adds update_string_column_len to a DSSDatasetSettings class in dataikuapi.dss.dataset.py. 

The function takes two inputs:
column - column name as it appears in the schema
length - an integer to set the column length

Conitnued development:
Add error handling to prevent setting the length beyond the maximum set by the connection type
Expand to other column types

I updated the local copy dataiku-api-client-python and was able to successfully update a string column length. 